### PR TITLE
Remove Amazon and Google ads

### DIFF
--- a/group/1.html
+++ b/group/1.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/10.html
+++ b/group/10.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/100.html
+++ b/group/100.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/101.html
+++ b/group/101.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/102.html
+++ b/group/102.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/103.html
+++ b/group/103.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/104.html
+++ b/group/104.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/105.html
+++ b/group/105.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/106.html
+++ b/group/106.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/107.html
+++ b/group/107.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/108.html
+++ b/group/108.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/109.html
+++ b/group/109.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/11.html
+++ b/group/11.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/110.html
+++ b/group/110.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/111.html
+++ b/group/111.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/112.html
+++ b/group/112.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/113.html
+++ b/group/113.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/114.html
+++ b/group/114.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/115.html
+++ b/group/115.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/116.html
+++ b/group/116.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/117.html
+++ b/group/117.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/118.html
+++ b/group/118.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/119.html
+++ b/group/119.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/12.html
+++ b/group/12.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/120.html
+++ b/group/120.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/121.html
+++ b/group/121.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/122.html
+++ b/group/122.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/123.html
+++ b/group/123.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/124.html
+++ b/group/124.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/125.html
+++ b/group/125.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/126.html
+++ b/group/126.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/127.html
+++ b/group/127.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/128.html
+++ b/group/128.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/129.html
+++ b/group/129.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/130.html
+++ b/group/130.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/131.html
+++ b/group/131.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/132.html
+++ b/group/132.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/133.html
+++ b/group/133.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/134.html
+++ b/group/134.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/135.html
+++ b/group/135.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/136.html
+++ b/group/136.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/137.html
+++ b/group/137.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/138.html
+++ b/group/138.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/139.html
+++ b/group/139.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/140.html
+++ b/group/140.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/141.html
+++ b/group/141.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/142.html
+++ b/group/142.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/143.html
+++ b/group/143.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/144.html
+++ b/group/144.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/145.html
+++ b/group/145.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/146.html
+++ b/group/146.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/147.html
+++ b/group/147.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/148.html
+++ b/group/148.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/149.html
+++ b/group/149.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/150.html
+++ b/group/150.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/151.html
+++ b/group/151.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/152.html
+++ b/group/152.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/153.html
+++ b/group/153.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/154.html
+++ b/group/154.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/155.html
+++ b/group/155.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/156.html
+++ b/group/156.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/157.html
+++ b/group/157.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/158.html
+++ b/group/158.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/159.html
+++ b/group/159.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/16.html
+++ b/group/16.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/160.html
+++ b/group/160.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/161.html
+++ b/group/161.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/162.html
+++ b/group/162.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/163.html
+++ b/group/163.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/164.html
+++ b/group/164.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/165.html
+++ b/group/165.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/166.html
+++ b/group/166.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/167.html
+++ b/group/167.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/168.html
+++ b/group/168.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/169.html
+++ b/group/169.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/17.html
+++ b/group/17.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/170.html
+++ b/group/170.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/171.html
+++ b/group/171.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/172.html
+++ b/group/172.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/173.html
+++ b/group/173.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/174.html
+++ b/group/174.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/175.html
+++ b/group/175.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/176.html
+++ b/group/176.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/177.html
+++ b/group/177.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/178.html
+++ b/group/178.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/179.html
+++ b/group/179.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/18.html
+++ b/group/18.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/180.html
+++ b/group/180.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/181.html
+++ b/group/181.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/182.html
+++ b/group/182.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/183.html
+++ b/group/183.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/184.html
+++ b/group/184.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/185.html
+++ b/group/185.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/186.html
+++ b/group/186.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/187.html
+++ b/group/187.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/188.html
+++ b/group/188.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/189.html
+++ b/group/189.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/19.html
+++ b/group/19.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/190.html
+++ b/group/190.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/191.html
+++ b/group/191.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/192.html
+++ b/group/192.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/193.html
+++ b/group/193.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/194.html
+++ b/group/194.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/195.html
+++ b/group/195.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/196.html
+++ b/group/196.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/197.html
+++ b/group/197.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/198.html
+++ b/group/198.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/199.html
+++ b/group/199.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/2.html
+++ b/group/2.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/20.html
+++ b/group/20.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/200.html
+++ b/group/200.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/201.html
+++ b/group/201.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/202.html
+++ b/group/202.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/203.html
+++ b/group/203.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/204.html
+++ b/group/204.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/205.html
+++ b/group/205.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/206.html
+++ b/group/206.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/207.html
+++ b/group/207.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/208.html
+++ b/group/208.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/209.html
+++ b/group/209.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/21.html
+++ b/group/21.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/210.html
+++ b/group/210.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/211.html
+++ b/group/211.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/212.html
+++ b/group/212.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/213.html
+++ b/group/213.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/214.html
+++ b/group/214.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/215.html
+++ b/group/215.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/216.html
+++ b/group/216.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/217.html
+++ b/group/217.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/218.html
+++ b/group/218.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/219.html
+++ b/group/219.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/22.html
+++ b/group/22.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/220.html
+++ b/group/220.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/221.html
+++ b/group/221.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/222.html
+++ b/group/222.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/223.html
+++ b/group/223.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/224.html
+++ b/group/224.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/225.html
+++ b/group/225.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/226.html
+++ b/group/226.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/227.html
+++ b/group/227.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/228.html
+++ b/group/228.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/229.html
+++ b/group/229.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/23.html
+++ b/group/23.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/230.html
+++ b/group/230.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/231.html
+++ b/group/231.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/232.html
+++ b/group/232.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/233.html
+++ b/group/233.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/234.html
+++ b/group/234.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/235.html
+++ b/group/235.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/236.html
+++ b/group/236.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/237.html
+++ b/group/237.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/238.html
+++ b/group/238.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/239.html
+++ b/group/239.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/24.html
+++ b/group/24.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/240.html
+++ b/group/240.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/241.html
+++ b/group/241.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/242.html
+++ b/group/242.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/243.html
+++ b/group/243.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/244.html
+++ b/group/244.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/245.html
+++ b/group/245.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/246.html
+++ b/group/246.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/247.html
+++ b/group/247.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/248.html
+++ b/group/248.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/249.html
+++ b/group/249.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/25.html
+++ b/group/25.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/250.html
+++ b/group/250.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/251.html
+++ b/group/251.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/252.html
+++ b/group/252.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/253.html
+++ b/group/253.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/254.html
+++ b/group/254.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/255.html
+++ b/group/255.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/256.html
+++ b/group/256.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/257.html
+++ b/group/257.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/258.html
+++ b/group/258.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/259.html
+++ b/group/259.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/26.html
+++ b/group/26.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/260.html
+++ b/group/260.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/261.html
+++ b/group/261.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/262.html
+++ b/group/262.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/263.html
+++ b/group/263.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/264.html
+++ b/group/264.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/265.html
+++ b/group/265.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/266.html
+++ b/group/266.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/267.html
+++ b/group/267.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/268.html
+++ b/group/268.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/269.html
+++ b/group/269.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/27.html
+++ b/group/27.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/270.html
+++ b/group/270.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/271.html
+++ b/group/271.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/272.html
+++ b/group/272.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/273.html
+++ b/group/273.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/274.html
+++ b/group/274.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/275.html
+++ b/group/275.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/276.html
+++ b/group/276.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/277.html
+++ b/group/277.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/278.html
+++ b/group/278.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/279.html
+++ b/group/279.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/28.html
+++ b/group/28.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/280.html
+++ b/group/280.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/281.html
+++ b/group/281.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/282.html
+++ b/group/282.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/283.html
+++ b/group/283.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/284.html
+++ b/group/284.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/285.html
+++ b/group/285.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/286.html
+++ b/group/286.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/287.html
+++ b/group/287.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/288.html
+++ b/group/288.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/289.html
+++ b/group/289.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/29.html
+++ b/group/29.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/290.html
+++ b/group/290.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/291.html
+++ b/group/291.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/292.html
+++ b/group/292.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/293.html
+++ b/group/293.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/294.html
+++ b/group/294.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/295.html
+++ b/group/295.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/296.html
+++ b/group/296.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/297.html
+++ b/group/297.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/298.html
+++ b/group/298.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/299.html
+++ b/group/299.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/3.html
+++ b/group/3.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/30.html
+++ b/group/30.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/300.html
+++ b/group/300.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/301.html
+++ b/group/301.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/302.html
+++ b/group/302.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/303.html
+++ b/group/303.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/304.html
+++ b/group/304.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/305.html
+++ b/group/305.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/306.html
+++ b/group/306.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/307.html
+++ b/group/307.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/308.html
+++ b/group/308.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/309.html
+++ b/group/309.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -113,7 +98,7 @@ Reinhard
 &gt; 
 &gt; ---------------------------------
 &gt; Do you Yahoo!?
-&gt; Meet the all-new My Yahoo! – Try it today! 
+&gt; Meet the all-new My Yahoo! â€“ Try it today! 
 &gt; 
 &gt; [Non-text portions of this message have been
 &gt; removed]
@@ -137,7 +122,7 @@ Reinhard
 &gt; 
 &gt; ---------------------------------
 &gt; Do you Yahoo!?
-&gt; Discover all that’s new in My Yahoo!
+&gt; Discover all thatâ€™s new in My Yahoo!
 &gt; 
 &gt; [Non-text portions of this message have been
 &gt; removed]

--- a/group/31.html
+++ b/group/31.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/310.html
+++ b/group/310.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/311.html
+++ b/group/311.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/312.html
+++ b/group/312.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/313.html
+++ b/group/313.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/314.html
+++ b/group/314.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/315.html
+++ b/group/315.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/316.html
+++ b/group/316.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/317.html
+++ b/group/317.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/318.html
+++ b/group/318.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/319.html
+++ b/group/319.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/32.html
+++ b/group/32.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/320.html
+++ b/group/320.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/321.html
+++ b/group/321.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/322.html
+++ b/group/322.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/323.html
+++ b/group/323.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/324.html
+++ b/group/324.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/325.html
+++ b/group/325.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/326.html
+++ b/group/326.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/327.html
+++ b/group/327.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/328.html
+++ b/group/328.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/329.html
+++ b/group/329.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/33.html
+++ b/group/33.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/330.html
+++ b/group/330.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/331.html
+++ b/group/331.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/332.html
+++ b/group/332.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/333.html
+++ b/group/333.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/334.html
+++ b/group/334.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/335.html
+++ b/group/335.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/336.html
+++ b/group/336.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/337.html
+++ b/group/337.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/338.html
+++ b/group/338.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/339.html
+++ b/group/339.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/34.html
+++ b/group/34.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -73,7 +58,7 @@ Hmm, none of the videos played, unfortunately.
 
 __________________________________
 Do you Yahoo!?
-Yahoo! Search - Find what you’re looking for faster
+Yahoo! Search - Find what youâ€™re looking for faster
 <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 </pre>
 

--- a/group/340.html
+++ b/group/340.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/341.html
+++ b/group/341.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/342.html
+++ b/group/342.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/343.html
+++ b/group/343.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/344.html
+++ b/group/344.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/345.html
+++ b/group/345.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/346.html
+++ b/group/346.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/347.html
+++ b/group/347.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/348.html
+++ b/group/348.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/349.html
+++ b/group/349.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/35.html
+++ b/group/35.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -81,7 +66,7 @@ the rest and add an extra link.
 &gt; 
 &gt; __________________________________
 &gt; Do you Yahoo!?
-&gt; Yahoo! Search - Find what you’re looking for faster
+&gt; Yahoo! Search - Find what youâ€™re looking for faster
 &gt; <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 &gt; 
 &gt; 

--- a/group/350.html
+++ b/group/350.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/351.html
+++ b/group/351.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/352.html
+++ b/group/352.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/353.html
+++ b/group/353.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/354.html
+++ b/group/354.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/355.html
+++ b/group/355.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/356.html
+++ b/group/356.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/357.html
+++ b/group/357.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/358.html
+++ b/group/358.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/359.html
+++ b/group/359.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/36.html
+++ b/group/36.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -89,7 +74,7 @@ I wonder why not this one.
 &gt; &gt; 
 &gt; &gt; __________________________________
 &gt; &gt; Do you Yahoo!?
-&gt; &gt; Yahoo! Search - Find what you’re looking for
+&gt; &gt; Yahoo! Search - Find what youâ€™re looking for
 &gt; faster
 &gt; &gt; <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 &gt; &gt; 
@@ -118,7 +103,7 @@ I wonder why not this one.
 
 __________________________________
 Do you Yahoo!?
-Yahoo! Search - Find what you’re looking for faster
+Yahoo! Search - Find what youâ€™re looking for faster
 <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 </pre>
 

--- a/group/360.html
+++ b/group/360.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/361.html
+++ b/group/361.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/362.html
+++ b/group/362.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/363.html
+++ b/group/363.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/364.html
+++ b/group/364.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/365.html
+++ b/group/365.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/366.html
+++ b/group/366.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/367.html
+++ b/group/367.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/368.html
+++ b/group/368.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/369.html
+++ b/group/369.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/37.html
+++ b/group/37.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -101,7 +86,7 @@ was wrong.
 &gt; &gt; &gt; 
 &gt; &gt; &gt; __________________________________
 &gt; &gt; &gt; Do you Yahoo!?
-&gt; &gt; &gt; Yahoo! Search - Find what you’re looking for
+&gt; &gt; &gt; Yahoo! Search - Find what youâ€™re looking for
 &gt; &gt; faster
 &gt; &gt; &gt; <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 &gt; &gt; &gt; 
@@ -130,7 +115,7 @@ was wrong.
 &gt; 
 &gt; __________________________________
 &gt; Do you Yahoo!?
-&gt; Yahoo! Search - Find what you’re looking for faster
+&gt; Yahoo! Search - Find what youâ€™re looking for faster
 &gt; <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 &gt; 
 &gt; 

--- a/group/370.html
+++ b/group/370.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/371.html
+++ b/group/371.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/372.html
+++ b/group/372.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -153,7 +138,7 @@ Thanks
 &gt; 
 &gt; ---------------------------------
 &gt; Do you Yahoo!?
-&gt; All your favorites on one personal page – Try My
+&gt; All your favorites on one personal page â€“ Try My
 &gt; Yahoo!
 &gt; 
 &gt; [Non-text portions of this message have been

--- a/group/373.html
+++ b/group/373.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/374.html
+++ b/group/374.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/375.html
+++ b/group/375.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/376.html
+++ b/group/376.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/377.html
+++ b/group/377.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/378.html
+++ b/group/378.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/379.html
+++ b/group/379.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/38.html
+++ b/group/38.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -104,7 +89,7 @@ Ah! Glad to be of service!
 &gt; &gt; &gt; &gt; 
 &gt; &gt; &gt; &gt; __________________________________
 &gt; &gt; &gt; &gt; Do you Yahoo!?
-&gt; &gt; &gt; &gt; Yahoo! Search - Find what you’re looking for
+&gt; &gt; &gt; &gt; Yahoo! Search - Find what youâ€™re looking for
 &gt; &gt; &gt; faster
 &gt; &gt; &gt; &gt; <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 &gt; &gt; &gt; &gt; 
@@ -133,7 +118,7 @@ Ah! Glad to be of service!
 &gt; &gt; 
 &gt; &gt; __________________________________
 &gt; &gt; Do you Yahoo!?
-&gt; &gt; Yahoo! Search - Find what you’re looking for
+&gt; &gt; Yahoo! Search - Find what youâ€™re looking for
 &gt; faster
 &gt; &gt; <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 &gt; &gt; 
@@ -160,7 +145,7 @@ Ah! Glad to be of service!
 
 __________________________________
 Do you Yahoo!?
-Yahoo! Search - Find what you’re looking for faster
+Yahoo! Search - Find what youâ€™re looking for faster
 <a href="http://search.yahoo.com">http://search.yahoo.com</a>
 </pre>
 

--- a/group/380.html
+++ b/group/380.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/381.html
+++ b/group/381.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/382.html
+++ b/group/382.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/383.html
+++ b/group/383.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/384.html
+++ b/group/384.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/385.html
+++ b/group/385.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/386.html
+++ b/group/386.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/387.html
+++ b/group/387.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/388.html
+++ b/group/388.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/389.html
+++ b/group/389.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/39.html
+++ b/group/39.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/390.html
+++ b/group/390.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/391.html
+++ b/group/391.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/392.html
+++ b/group/392.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/393.html
+++ b/group/393.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/394.html
+++ b/group/394.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/395.html
+++ b/group/395.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/396.html
+++ b/group/396.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/397.html
+++ b/group/397.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/398.html
+++ b/group/398.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/399.html
+++ b/group/399.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/4.html
+++ b/group/4.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/40.html
+++ b/group/40.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/400.html
+++ b/group/400.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/401.html
+++ b/group/401.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/402.html
+++ b/group/402.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/403.html
+++ b/group/403.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/404.html
+++ b/group/404.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/405.html
+++ b/group/405.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/406.html
+++ b/group/406.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/407.html
+++ b/group/407.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/408.html
+++ b/group/408.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/409.html
+++ b/group/409.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/41.html
+++ b/group/41.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/410.html
+++ b/group/410.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/411.html
+++ b/group/411.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/412.html
+++ b/group/412.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/413.html
+++ b/group/413.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/414.html
+++ b/group/414.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/415.html
+++ b/group/415.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/416.html
+++ b/group/416.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/417.html
+++ b/group/417.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/418.html
+++ b/group/418.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/419.html
+++ b/group/419.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/42.html
+++ b/group/42.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/420.html
+++ b/group/420.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/421.html
+++ b/group/421.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/422.html
+++ b/group/422.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/423.html
+++ b/group/423.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/424.html
+++ b/group/424.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/425.html
+++ b/group/425.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/426.html
+++ b/group/426.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/427.html
+++ b/group/427.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/428.html
+++ b/group/428.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/429.html
+++ b/group/429.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/43.html
+++ b/group/43.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/430.html
+++ b/group/430.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/431.html
+++ b/group/431.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/432.html
+++ b/group/432.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/433.html
+++ b/group/433.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/434.html
+++ b/group/434.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/435.html
+++ b/group/435.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/436.html
+++ b/group/436.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/437.html
+++ b/group/437.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/438.html
+++ b/group/438.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/439.html
+++ b/group/439.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/44.html
+++ b/group/44.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/440.html
+++ b/group/440.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/441.html
+++ b/group/441.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -175,7 +160,7 @@ Richard.
 
 __________________________________ 
 Do you Yahoo!? 
-All your favorites on one personal page – Try My Yahoo!
+All your favorites on one personal page â€“ Try My Yahoo!
 <a href="http://my.yahoo.com">http://my.yahoo.com</a>
 </pre>
 

--- a/group/442.html
+++ b/group/442.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/443.html
+++ b/group/443.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/444.html
+++ b/group/444.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/445.html
+++ b/group/445.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/446.html
+++ b/group/446.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/447.html
+++ b/group/447.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/448.html
+++ b/group/448.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/449.html
+++ b/group/449.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/45.html
+++ b/group/45.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/450.html
+++ b/group/450.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/451.html
+++ b/group/451.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/452.html
+++ b/group/452.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/453.html
+++ b/group/453.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/454.html
+++ b/group/454.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/455.html
+++ b/group/455.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/456.html
+++ b/group/456.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/457.html
+++ b/group/457.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/458.html
+++ b/group/458.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/459.html
+++ b/group/459.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/46.html
+++ b/group/46.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/460.html
+++ b/group/460.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/461.html
+++ b/group/461.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/462.html
+++ b/group/462.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/463.html
+++ b/group/463.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/464.html
+++ b/group/464.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/465.html
+++ b/group/465.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -88,7 +73,7 @@ Thanks Storm Fox
 &gt; 
 &gt; ---------------------------------
 &gt; Do you Yahoo!?
-&gt; Meet the all-new My Yahoo! – Try it today! 
+&gt; Meet the all-new My Yahoo! â€“ Try it today! 
 &gt; 
 &gt; [Non-text portions of this message have been
 &gt; removed]
@@ -126,7 +111,7 @@ Thanks Storm Fox
 
 __________________________________ 
 Do you Yahoo!? 
-All your favorites on one personal page – Try My Yahoo!
+All your favorites on one personal page â€“ Try My Yahoo!
 <a href="http://my.yahoo.com">http://my.yahoo.com</a>
 </pre>
 

--- a/group/466.html
+++ b/group/466.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/467.html
+++ b/group/467.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/468.html
+++ b/group/468.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/469.html
+++ b/group/469.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/47.html
+++ b/group/47.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/470.html
+++ b/group/470.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/471.html
+++ b/group/471.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/472.html
+++ b/group/472.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/473.html
+++ b/group/473.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/474.html
+++ b/group/474.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/475.html
+++ b/group/475.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/476.html
+++ b/group/476.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/477.html
+++ b/group/477.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/478.html
+++ b/group/478.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/479.html
+++ b/group/479.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/48.html
+++ b/group/48.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/480.html
+++ b/group/480.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/481.html
+++ b/group/481.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/482.html
+++ b/group/482.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/483.html
+++ b/group/483.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/484.html
+++ b/group/484.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/485.html
+++ b/group/485.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -140,7 +125,7 @@ R.Spears
 
 __________________________________ 
 Do you Yahoo!? 
-All your favorites on one personal page – Try My Yahoo!
+All your favorites on one personal page â€“ Try My Yahoo!
 <a href="http://my.yahoo.com">http://my.yahoo.com</a>
 </pre>
 

--- a/group/486.html
+++ b/group/486.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/487.html
+++ b/group/487.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/488.html
+++ b/group/488.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/489.html
+++ b/group/489.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/49.html
+++ b/group/49.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/490.html
+++ b/group/490.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/491.html
+++ b/group/491.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/492.html
+++ b/group/492.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/493.html
+++ b/group/493.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/494.html
+++ b/group/494.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/495.html
+++ b/group/495.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/496.html
+++ b/group/496.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/497.html
+++ b/group/497.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/498.html
+++ b/group/498.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/499.html
+++ b/group/499.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/5.html
+++ b/group/5.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/50.html
+++ b/group/50.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/500.html
+++ b/group/500.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/501.html
+++ b/group/501.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/502.html
+++ b/group/502.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/503.html
+++ b/group/503.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/504.html
+++ b/group/504.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/505.html
+++ b/group/505.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/506.html
+++ b/group/506.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/507.html
+++ b/group/507.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/508.html
+++ b/group/508.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/509.html
+++ b/group/509.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/51.html
+++ b/group/51.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/510.html
+++ b/group/510.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/511.html
+++ b/group/511.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/512.html
+++ b/group/512.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/513.html
+++ b/group/513.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/514.html
+++ b/group/514.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/515.html
+++ b/group/515.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/516.html
+++ b/group/516.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/517.html
+++ b/group/517.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/518.html
+++ b/group/518.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/519.html
+++ b/group/519.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/52.html
+++ b/group/52.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/520.html
+++ b/group/520.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/521.html
+++ b/group/521.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/522.html
+++ b/group/522.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/523.html
+++ b/group/523.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/524.html
+++ b/group/524.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/525.html
+++ b/group/525.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/526.html
+++ b/group/526.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/527.html
+++ b/group/527.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/528.html
+++ b/group/528.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/529.html
+++ b/group/529.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/53.html
+++ b/group/53.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/530.html
+++ b/group/530.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/531.html
+++ b/group/531.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/532.html
+++ b/group/532.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/533.html
+++ b/group/533.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/534.html
+++ b/group/534.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/535.html
+++ b/group/535.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/536.html
+++ b/group/536.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/537.html
+++ b/group/537.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/538.html
+++ b/group/538.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/539.html
+++ b/group/539.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/54.html
+++ b/group/54.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/540.html
+++ b/group/540.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/541.html
+++ b/group/541.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/542.html
+++ b/group/542.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/543.html
+++ b/group/543.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/544.html
+++ b/group/544.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/545.html
+++ b/group/545.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/546.html
+++ b/group/546.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/547.html
+++ b/group/547.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/548.html
+++ b/group/548.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/549.html
+++ b/group/549.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/55.html
+++ b/group/55.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/550.html
+++ b/group/550.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/551.html
+++ b/group/551.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/552.html
+++ b/group/552.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/553.html
+++ b/group/553.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/554.html
+++ b/group/554.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/555.html
+++ b/group/555.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/556.html
+++ b/group/556.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/557.html
+++ b/group/557.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/558.html
+++ b/group/558.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/559.html
+++ b/group/559.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/56.html
+++ b/group/56.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/560.html
+++ b/group/560.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/561.html
+++ b/group/561.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/562.html
+++ b/group/562.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/563.html
+++ b/group/563.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/564.html
+++ b/group/564.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/565.html
+++ b/group/565.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/566.html
+++ b/group/566.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/567.html
+++ b/group/567.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/568.html
+++ b/group/568.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/569.html
+++ b/group/569.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/57.html
+++ b/group/57.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/570.html
+++ b/group/570.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/571.html
+++ b/group/571.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/572.html
+++ b/group/572.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/573.html
+++ b/group/573.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/574.html
+++ b/group/574.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/575.html
+++ b/group/575.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/576.html
+++ b/group/576.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/577.html
+++ b/group/577.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/578.html
+++ b/group/578.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/579.html
+++ b/group/579.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/58.html
+++ b/group/58.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/580.html
+++ b/group/580.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/581.html
+++ b/group/581.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/582.html
+++ b/group/582.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/583.html
+++ b/group/583.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/584.html
+++ b/group/584.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/585.html
+++ b/group/585.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/586.html
+++ b/group/586.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/587.html
+++ b/group/587.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/588.html
+++ b/group/588.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/589.html
+++ b/group/589.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/59.html
+++ b/group/59.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/590.html
+++ b/group/590.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/591.html
+++ b/group/591.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/592.html
+++ b/group/592.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/593.html
+++ b/group/593.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/594.html
+++ b/group/594.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/595.html
+++ b/group/595.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/596.html
+++ b/group/596.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/597.html
+++ b/group/597.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/598.html
+++ b/group/598.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/599.html
+++ b/group/599.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/6.html
+++ b/group/6.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/60.html
+++ b/group/60.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/600.html
+++ b/group/600.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/601.html
+++ b/group/601.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/602.html
+++ b/group/602.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/603.html
+++ b/group/603.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/604.html
+++ b/group/604.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/605.html
+++ b/group/605.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/606.html
+++ b/group/606.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/607.html
+++ b/group/607.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/608.html
+++ b/group/608.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/609.html
+++ b/group/609.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/61.html
+++ b/group/61.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/610.html
+++ b/group/610.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/611.html
+++ b/group/611.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/612.html
+++ b/group/612.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/613.html
+++ b/group/613.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/614.html
+++ b/group/614.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/615.html
+++ b/group/615.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/616.html
+++ b/group/616.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/617.html
+++ b/group/617.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/618.html
+++ b/group/618.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/619.html
+++ b/group/619.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/62.html
+++ b/group/62.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/620.html
+++ b/group/620.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/621.html
+++ b/group/621.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/622.html
+++ b/group/622.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/623.html
+++ b/group/623.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/624.html
+++ b/group/624.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/625.html
+++ b/group/625.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/626.html
+++ b/group/626.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/627.html
+++ b/group/627.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/628.html
+++ b/group/628.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/629.html
+++ b/group/629.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/63.html
+++ b/group/63.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/630.html
+++ b/group/630.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/631.html
+++ b/group/631.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/632.html
+++ b/group/632.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/633.html
+++ b/group/633.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/634.html
+++ b/group/634.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/635.html
+++ b/group/635.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/636.html
+++ b/group/636.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/637.html
+++ b/group/637.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/638.html
+++ b/group/638.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/639.html
+++ b/group/639.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/64.html
+++ b/group/64.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/640.html
+++ b/group/640.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/641.html
+++ b/group/641.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/642.html
+++ b/group/642.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/643.html
+++ b/group/643.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/644.html
+++ b/group/644.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/645.html
+++ b/group/645.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/646.html
+++ b/group/646.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/647.html
+++ b/group/647.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/648.html
+++ b/group/648.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/649.html
+++ b/group/649.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/65.html
+++ b/group/65.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/66.html
+++ b/group/66.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/67.html
+++ b/group/67.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/68.html
+++ b/group/68.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/69.html
+++ b/group/69.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/7.html
+++ b/group/7.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/70.html
+++ b/group/70.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/71.html
+++ b/group/71.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/72.html
+++ b/group/72.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/73.html
+++ b/group/73.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/74.html
+++ b/group/74.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/75.html
+++ b/group/75.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/76.html
+++ b/group/76.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/77.html
+++ b/group/77.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/78.html
+++ b/group/78.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/79.html
+++ b/group/79.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/8.html
+++ b/group/8.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/80.html
+++ b/group/80.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/81.html
+++ b/group/81.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/82.html
+++ b/group/82.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/83.html
+++ b/group/83.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/84.html
+++ b/group/84.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/85.html
+++ b/group/85.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/86.html
+++ b/group/86.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/87.html
+++ b/group/87.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/88.html
+++ b/group/88.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/89.html
+++ b/group/89.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/9.html
+++ b/group/9.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/90.html
+++ b/group/90.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/91.html
+++ b/group/91.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/92.html
+++ b/group/92.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/93.html
+++ b/group/93.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/94.html
+++ b/group/94.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/95.html
+++ b/group/95.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/96.html
+++ b/group/96.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/97.html
+++ b/group/97.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/98.html
+++ b/group/98.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/group/99.html
+++ b/group/99.html
@@ -31,21 +31,6 @@ urchinTracker();
 
 
 <table cellspacing=0 cellpadding=0 width=25% align=right border=0><tr><td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/movements/chop_tree/index.html
+++ b/movements/chop_tree/index.html
@@ -99,38 +99,11 @@ Reinhard
 
 <tr>
 <td>
-<script type="text/javascript"><!--
-amazon_ad_tag="shovelglove-20"; 
-amazon_ad_width="160"; 
-amazon_ad_height="600"; 
-amazon_color_border="C80109"; 
-amazon_color_logo="FFFFFF"; 
-amazon_color_link="C80109"; 
-amazon_ad_logo="hide"; 
-amazon_ad_title="Shovelglove Sledgehammer Store"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/asw.js"></script>
-</td>
-</tr>
 
 <tr><td>&nbsp;</td></tr>
 
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -140,11 +113,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/chop_wood/index.html
+++ b/movements/chop_wood/index.html
@@ -61,21 +61,6 @@ pointing out a glaring typo on this page.</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -85,11 +70,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/churn_butter/index.html
+++ b/movements/churn_butter/index.html
@@ -46,21 +46,6 @@ masturbatory.</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -70,11 +55,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/drive_fence_posts/index.html
+++ b/movements/drive_fence_posts/index.html
@@ -60,21 +60,6 @@ months..</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -84,11 +69,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/fireman/index.html
+++ b/movements/fireman/index.html
@@ -60,11 +60,6 @@ doing it again, but just 14 very careful reps per set.</p>
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/flip_lever/index.html
+++ b/movements/flip_lever/index.html
@@ -48,21 +48,6 @@ so metaphorical, though). So "no name" now has three names (counting
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -72,11 +57,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/hoist_sack/index.html
+++ b/movements/hoist_sack/index.html
@@ -58,21 +58,6 @@ churn</a> and just one for this.</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -82,11 +67,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/shovel/index.html
+++ b/movements/shovel/index.html
@@ -38,21 +38,6 @@ back twister, so be careful.</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -62,11 +47,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/stoke_oven/index.html
+++ b/movements/stoke_oven/index.html
@@ -53,21 +53,6 @@ forearms and abdomen most.</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
-//--></script>
-<script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>
@@ -77,11 +62,6 @@ google_color_text = "000000";
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 <hr />
 

--- a/movements/tuck_bales/index.html
+++ b/movements/tuck_bales/index.html
@@ -52,11 +52,6 @@ neck.</p>
 </table>
 
 
-<p>
-<script type="text/javascript"><!--
-  amazon_ad_tag = "everydaysyste-20"; amazon_ad_width = "728"; amazon_ad_height = "90"; //--></script>
-<script type="text/javascript" src="http://www.assoc-amazon.com/s/ads.js"></script>
-</p>
 
 
 <hr />

--- a/testimonials.html
+++ b/testimonials.html
@@ -198,21 +198,8 @@ Testimonials Page</a> for related inspiration.</p>
 <table border="0" cellpadding="0" cellspacing="0">
 <tr>
 <td>
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
 //--></script>
 <script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 </tr>
 </table>

--- a/useful_vs_functional.html
+++ b/useful_vs_functional.html
@@ -84,21 +84,8 @@ fun.</p>
 </td>
 
 <td valign="top">
-<script type="text/javascript"><!--
-google_ad_client = "pub-6780333222270940";
-google_ad_width = 160;
-google_ad_height = 600;
-google_ad_format = "160x600_as";
-google_ad_channel ="";
-google_color_border = "000000";
-google_color_bg = "F0F0F0";
-google_color_link = "0000FF";
-google_color_url = "008000";
-google_color_text = "000000";
 //--></script>
 <script type="text/javascript"
-  src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-</script>
 </td>
 
 </tr></table><!-- main table -->


### PR DESCRIPTION
## Summary
- remove Amazon Associates ad scripts from movement pages
- remove Google ad scripts from group archives and other pages

## Testing
- `grep -R "google_ad" -n`
- `grep -R "amazon_ad" -n`

------
https://chatgpt.com/codex/tasks/task_e_685c5dc6b278832ba60ecd88048c2841