### PR TITLE
Remove legacy Google Analytics scripts

### DIFF
--- a/group/1.html
+++ b/group/1.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/10.html
+++ b/group/10.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/100.html
+++ b/group/100.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/101.html
+++ b/group/101.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/102.html
+++ b/group/102.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/103.html
+++ b/group/103.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/104.html
+++ b/group/104.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/105.html
+++ b/group/105.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/106.html
+++ b/group/106.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/107.html
+++ b/group/107.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/108.html
+++ b/group/108.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/109.html
+++ b/group/109.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/11.html
+++ b/group/11.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/110.html
+++ b/group/110.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/111.html
+++ b/group/111.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/112.html
+++ b/group/112.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/113.html
+++ b/group/113.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/114.html
+++ b/group/114.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/115.html
+++ b/group/115.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/116.html
+++ b/group/116.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/117.html
+++ b/group/117.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/118.html
+++ b/group/118.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/119.html
+++ b/group/119.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/12.html
+++ b/group/12.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/120.html
+++ b/group/120.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/121.html
+++ b/group/121.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/122.html
+++ b/group/122.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/123.html
+++ b/group/123.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/124.html
+++ b/group/124.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/125.html
+++ b/group/125.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/126.html
+++ b/group/126.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/127.html
+++ b/group/127.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/128.html
+++ b/group/128.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/129.html
+++ b/group/129.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/130.html
+++ b/group/130.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/131.html
+++ b/group/131.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/132.html
+++ b/group/132.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/133.html
+++ b/group/133.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/134.html
+++ b/group/134.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/135.html
+++ b/group/135.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/136.html
+++ b/group/136.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/137.html
+++ b/group/137.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/138.html
+++ b/group/138.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/139.html
+++ b/group/139.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/140.html
+++ b/group/140.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/141.html
+++ b/group/141.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/142.html
+++ b/group/142.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/143.html
+++ b/group/143.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/144.html
+++ b/group/144.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/145.html
+++ b/group/145.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/146.html
+++ b/group/146.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/147.html
+++ b/group/147.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/148.html
+++ b/group/148.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/149.html
+++ b/group/149.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/150.html
+++ b/group/150.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/151.html
+++ b/group/151.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/152.html
+++ b/group/152.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/153.html
+++ b/group/153.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/154.html
+++ b/group/154.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/155.html
+++ b/group/155.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/156.html
+++ b/group/156.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/157.html
+++ b/group/157.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/158.html
+++ b/group/158.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/159.html
+++ b/group/159.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/16.html
+++ b/group/16.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/160.html
+++ b/group/160.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/161.html
+++ b/group/161.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/162.html
+++ b/group/162.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/163.html
+++ b/group/163.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/164.html
+++ b/group/164.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/165.html
+++ b/group/165.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/166.html
+++ b/group/166.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/167.html
+++ b/group/167.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/168.html
+++ b/group/168.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/169.html
+++ b/group/169.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/17.html
+++ b/group/17.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/170.html
+++ b/group/170.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/171.html
+++ b/group/171.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/172.html
+++ b/group/172.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/173.html
+++ b/group/173.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/174.html
+++ b/group/174.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/175.html
+++ b/group/175.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/176.html
+++ b/group/176.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/177.html
+++ b/group/177.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/178.html
+++ b/group/178.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/179.html
+++ b/group/179.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/18.html
+++ b/group/18.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/180.html
+++ b/group/180.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/181.html
+++ b/group/181.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/182.html
+++ b/group/182.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/183.html
+++ b/group/183.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/184.html
+++ b/group/184.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/185.html
+++ b/group/185.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/186.html
+++ b/group/186.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/187.html
+++ b/group/187.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/188.html
+++ b/group/188.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/189.html
+++ b/group/189.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/19.html
+++ b/group/19.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/190.html
+++ b/group/190.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/191.html
+++ b/group/191.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/192.html
+++ b/group/192.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/193.html
+++ b/group/193.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/194.html
+++ b/group/194.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/195.html
+++ b/group/195.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/196.html
+++ b/group/196.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/197.html
+++ b/group/197.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/198.html
+++ b/group/198.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/199.html
+++ b/group/199.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/2.html
+++ b/group/2.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/20.html
+++ b/group/20.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/200.html
+++ b/group/200.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/201.html
+++ b/group/201.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/202.html
+++ b/group/202.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/203.html
+++ b/group/203.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/204.html
+++ b/group/204.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/205.html
+++ b/group/205.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/206.html
+++ b/group/206.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/207.html
+++ b/group/207.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/208.html
+++ b/group/208.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/209.html
+++ b/group/209.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/21.html
+++ b/group/21.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/210.html
+++ b/group/210.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/211.html
+++ b/group/211.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/212.html
+++ b/group/212.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/213.html
+++ b/group/213.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/214.html
+++ b/group/214.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/215.html
+++ b/group/215.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/216.html
+++ b/group/216.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/217.html
+++ b/group/217.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/218.html
+++ b/group/218.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/219.html
+++ b/group/219.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/22.html
+++ b/group/22.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/220.html
+++ b/group/220.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/221.html
+++ b/group/221.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/222.html
+++ b/group/222.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/223.html
+++ b/group/223.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/224.html
+++ b/group/224.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/225.html
+++ b/group/225.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/226.html
+++ b/group/226.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/227.html
+++ b/group/227.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/228.html
+++ b/group/228.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/229.html
+++ b/group/229.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/23.html
+++ b/group/23.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/230.html
+++ b/group/230.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/231.html
+++ b/group/231.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/232.html
+++ b/group/232.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/233.html
+++ b/group/233.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/234.html
+++ b/group/234.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/235.html
+++ b/group/235.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/236.html
+++ b/group/236.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/237.html
+++ b/group/237.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/238.html
+++ b/group/238.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/239.html
+++ b/group/239.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/24.html
+++ b/group/24.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/240.html
+++ b/group/240.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/241.html
+++ b/group/241.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/242.html
+++ b/group/242.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/243.html
+++ b/group/243.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/244.html
+++ b/group/244.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/245.html
+++ b/group/245.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/246.html
+++ b/group/246.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/247.html
+++ b/group/247.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/248.html
+++ b/group/248.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/249.html
+++ b/group/249.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/25.html
+++ b/group/25.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/250.html
+++ b/group/250.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/251.html
+++ b/group/251.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/252.html
+++ b/group/252.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/253.html
+++ b/group/253.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/254.html
+++ b/group/254.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/255.html
+++ b/group/255.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/256.html
+++ b/group/256.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/257.html
+++ b/group/257.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/258.html
+++ b/group/258.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/259.html
+++ b/group/259.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/26.html
+++ b/group/26.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/260.html
+++ b/group/260.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/261.html
+++ b/group/261.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/262.html
+++ b/group/262.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/263.html
+++ b/group/263.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/264.html
+++ b/group/264.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/265.html
+++ b/group/265.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/266.html
+++ b/group/266.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/267.html
+++ b/group/267.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/268.html
+++ b/group/268.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/269.html
+++ b/group/269.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/27.html
+++ b/group/27.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/270.html
+++ b/group/270.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/271.html
+++ b/group/271.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/272.html
+++ b/group/272.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/273.html
+++ b/group/273.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/274.html
+++ b/group/274.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/275.html
+++ b/group/275.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/276.html
+++ b/group/276.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/277.html
+++ b/group/277.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/278.html
+++ b/group/278.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/279.html
+++ b/group/279.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/28.html
+++ b/group/28.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/280.html
+++ b/group/280.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/281.html
+++ b/group/281.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/282.html
+++ b/group/282.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/283.html
+++ b/group/283.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/284.html
+++ b/group/284.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/285.html
+++ b/group/285.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/286.html
+++ b/group/286.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/287.html
+++ b/group/287.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/288.html
+++ b/group/288.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/289.html
+++ b/group/289.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/29.html
+++ b/group/29.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/290.html
+++ b/group/290.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/291.html
+++ b/group/291.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/292.html
+++ b/group/292.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/293.html
+++ b/group/293.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/294.html
+++ b/group/294.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/295.html
+++ b/group/295.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/296.html
+++ b/group/296.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/297.html
+++ b/group/297.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/298.html
+++ b/group/298.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/299.html
+++ b/group/299.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/3.html
+++ b/group/3.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/30.html
+++ b/group/30.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/300.html
+++ b/group/300.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/301.html
+++ b/group/301.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/302.html
+++ b/group/302.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/303.html
+++ b/group/303.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/304.html
+++ b/group/304.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/305.html
+++ b/group/305.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/306.html
+++ b/group/306.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/307.html
+++ b/group/307.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/308.html
+++ b/group/308.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/309.html
+++ b/group/309.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/31.html
+++ b/group/31.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/310.html
+++ b/group/310.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/311.html
+++ b/group/311.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/312.html
+++ b/group/312.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/313.html
+++ b/group/313.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/314.html
+++ b/group/314.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/315.html
+++ b/group/315.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/316.html
+++ b/group/316.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/317.html
+++ b/group/317.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/318.html
+++ b/group/318.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/319.html
+++ b/group/319.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/32.html
+++ b/group/32.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/320.html
+++ b/group/320.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/321.html
+++ b/group/321.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/322.html
+++ b/group/322.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/323.html
+++ b/group/323.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/324.html
+++ b/group/324.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/325.html
+++ b/group/325.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/326.html
+++ b/group/326.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/327.html
+++ b/group/327.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/328.html
+++ b/group/328.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/329.html
+++ b/group/329.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/33.html
+++ b/group/33.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/330.html
+++ b/group/330.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/331.html
+++ b/group/331.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/332.html
+++ b/group/332.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/333.html
+++ b/group/333.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/334.html
+++ b/group/334.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/335.html
+++ b/group/335.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/336.html
+++ b/group/336.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/337.html
+++ b/group/337.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/338.html
+++ b/group/338.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/339.html
+++ b/group/339.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/34.html
+++ b/group/34.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/340.html
+++ b/group/340.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/341.html
+++ b/group/341.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/342.html
+++ b/group/342.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/343.html
+++ b/group/343.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/344.html
+++ b/group/344.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/345.html
+++ b/group/345.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/346.html
+++ b/group/346.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/347.html
+++ b/group/347.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/348.html
+++ b/group/348.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/349.html
+++ b/group/349.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/35.html
+++ b/group/35.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/350.html
+++ b/group/350.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/351.html
+++ b/group/351.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/352.html
+++ b/group/352.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/353.html
+++ b/group/353.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/354.html
+++ b/group/354.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/355.html
+++ b/group/355.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/356.html
+++ b/group/356.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/357.html
+++ b/group/357.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/358.html
+++ b/group/358.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/359.html
+++ b/group/359.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/36.html
+++ b/group/36.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/360.html
+++ b/group/360.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/361.html
+++ b/group/361.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/362.html
+++ b/group/362.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/363.html
+++ b/group/363.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/364.html
+++ b/group/364.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/365.html
+++ b/group/365.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/366.html
+++ b/group/366.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/367.html
+++ b/group/367.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/368.html
+++ b/group/368.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/369.html
+++ b/group/369.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/37.html
+++ b/group/37.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/370.html
+++ b/group/370.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/371.html
+++ b/group/371.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/372.html
+++ b/group/372.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/373.html
+++ b/group/373.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/374.html
+++ b/group/374.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/375.html
+++ b/group/375.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/376.html
+++ b/group/376.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/377.html
+++ b/group/377.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/378.html
+++ b/group/378.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/379.html
+++ b/group/379.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/38.html
+++ b/group/38.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/380.html
+++ b/group/380.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/381.html
+++ b/group/381.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/382.html
+++ b/group/382.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/383.html
+++ b/group/383.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/384.html
+++ b/group/384.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/385.html
+++ b/group/385.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/386.html
+++ b/group/386.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/387.html
+++ b/group/387.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/388.html
+++ b/group/388.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/389.html
+++ b/group/389.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/39.html
+++ b/group/39.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/390.html
+++ b/group/390.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/391.html
+++ b/group/391.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/392.html
+++ b/group/392.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/393.html
+++ b/group/393.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/394.html
+++ b/group/394.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/395.html
+++ b/group/395.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/396.html
+++ b/group/396.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/397.html
+++ b/group/397.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/398.html
+++ b/group/398.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/399.html
+++ b/group/399.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/4.html
+++ b/group/4.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/40.html
+++ b/group/40.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/400.html
+++ b/group/400.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/401.html
+++ b/group/401.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/402.html
+++ b/group/402.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/403.html
+++ b/group/403.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/404.html
+++ b/group/404.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/405.html
+++ b/group/405.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/406.html
+++ b/group/406.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/407.html
+++ b/group/407.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/408.html
+++ b/group/408.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/409.html
+++ b/group/409.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/41.html
+++ b/group/41.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/410.html
+++ b/group/410.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/411.html
+++ b/group/411.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/412.html
+++ b/group/412.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/413.html
+++ b/group/413.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/414.html
+++ b/group/414.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/415.html
+++ b/group/415.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/416.html
+++ b/group/416.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/417.html
+++ b/group/417.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/418.html
+++ b/group/418.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/419.html
+++ b/group/419.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/42.html
+++ b/group/42.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/420.html
+++ b/group/420.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/421.html
+++ b/group/421.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/422.html
+++ b/group/422.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/423.html
+++ b/group/423.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/424.html
+++ b/group/424.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/425.html
+++ b/group/425.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/426.html
+++ b/group/426.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/427.html
+++ b/group/427.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/428.html
+++ b/group/428.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/429.html
+++ b/group/429.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/43.html
+++ b/group/43.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/430.html
+++ b/group/430.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/431.html
+++ b/group/431.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/432.html
+++ b/group/432.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/433.html
+++ b/group/433.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/434.html
+++ b/group/434.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/435.html
+++ b/group/435.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/436.html
+++ b/group/436.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/437.html
+++ b/group/437.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/438.html
+++ b/group/438.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/439.html
+++ b/group/439.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/44.html
+++ b/group/44.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/440.html
+++ b/group/440.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/441.html
+++ b/group/441.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/442.html
+++ b/group/442.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/443.html
+++ b/group/443.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/444.html
+++ b/group/444.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/445.html
+++ b/group/445.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/446.html
+++ b/group/446.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/447.html
+++ b/group/447.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/448.html
+++ b/group/448.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/449.html
+++ b/group/449.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/45.html
+++ b/group/45.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/450.html
+++ b/group/450.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/451.html
+++ b/group/451.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/452.html
+++ b/group/452.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/453.html
+++ b/group/453.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/454.html
+++ b/group/454.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/455.html
+++ b/group/455.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/456.html
+++ b/group/456.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/457.html
+++ b/group/457.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/458.html
+++ b/group/458.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/459.html
+++ b/group/459.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/46.html
+++ b/group/46.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/460.html
+++ b/group/460.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/461.html
+++ b/group/461.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/462.html
+++ b/group/462.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/463.html
+++ b/group/463.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/464.html
+++ b/group/464.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/465.html
+++ b/group/465.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/466.html
+++ b/group/466.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/467.html
+++ b/group/467.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/468.html
+++ b/group/468.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/469.html
+++ b/group/469.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/47.html
+++ b/group/47.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/470.html
+++ b/group/470.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/471.html
+++ b/group/471.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/472.html
+++ b/group/472.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/473.html
+++ b/group/473.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/474.html
+++ b/group/474.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/475.html
+++ b/group/475.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/476.html
+++ b/group/476.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/477.html
+++ b/group/477.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/478.html
+++ b/group/478.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/479.html
+++ b/group/479.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/48.html
+++ b/group/48.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/480.html
+++ b/group/480.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/481.html
+++ b/group/481.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/482.html
+++ b/group/482.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/483.html
+++ b/group/483.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/484.html
+++ b/group/484.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/485.html
+++ b/group/485.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/486.html
+++ b/group/486.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/487.html
+++ b/group/487.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/488.html
+++ b/group/488.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/489.html
+++ b/group/489.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/49.html
+++ b/group/49.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/490.html
+++ b/group/490.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/491.html
+++ b/group/491.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/492.html
+++ b/group/492.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/493.html
+++ b/group/493.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/494.html
+++ b/group/494.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/495.html
+++ b/group/495.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/496.html
+++ b/group/496.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/497.html
+++ b/group/497.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/498.html
+++ b/group/498.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/499.html
+++ b/group/499.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/5.html
+++ b/group/5.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/50.html
+++ b/group/50.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/500.html
+++ b/group/500.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/501.html
+++ b/group/501.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/502.html
+++ b/group/502.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/503.html
+++ b/group/503.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/504.html
+++ b/group/504.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/505.html
+++ b/group/505.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/506.html
+++ b/group/506.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/507.html
+++ b/group/507.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/508.html
+++ b/group/508.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/509.html
+++ b/group/509.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/51.html
+++ b/group/51.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/510.html
+++ b/group/510.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/511.html
+++ b/group/511.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/512.html
+++ b/group/512.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/513.html
+++ b/group/513.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/514.html
+++ b/group/514.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/515.html
+++ b/group/515.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/516.html
+++ b/group/516.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/517.html
+++ b/group/517.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/518.html
+++ b/group/518.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/519.html
+++ b/group/519.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/52.html
+++ b/group/52.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/520.html
+++ b/group/520.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/521.html
+++ b/group/521.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/522.html
+++ b/group/522.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/523.html
+++ b/group/523.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/524.html
+++ b/group/524.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/525.html
+++ b/group/525.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/526.html
+++ b/group/526.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/527.html
+++ b/group/527.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/528.html
+++ b/group/528.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/529.html
+++ b/group/529.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/53.html
+++ b/group/53.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/530.html
+++ b/group/530.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/531.html
+++ b/group/531.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/532.html
+++ b/group/532.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/533.html
+++ b/group/533.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/534.html
+++ b/group/534.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/535.html
+++ b/group/535.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/536.html
+++ b/group/536.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/537.html
+++ b/group/537.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/538.html
+++ b/group/538.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/539.html
+++ b/group/539.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/54.html
+++ b/group/54.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/540.html
+++ b/group/540.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/541.html
+++ b/group/541.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/542.html
+++ b/group/542.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/543.html
+++ b/group/543.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/544.html
+++ b/group/544.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/545.html
+++ b/group/545.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/546.html
+++ b/group/546.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/547.html
+++ b/group/547.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/548.html
+++ b/group/548.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/549.html
+++ b/group/549.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/55.html
+++ b/group/55.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/550.html
+++ b/group/550.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/551.html
+++ b/group/551.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/552.html
+++ b/group/552.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/553.html
+++ b/group/553.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/554.html
+++ b/group/554.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/555.html
+++ b/group/555.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/556.html
+++ b/group/556.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/557.html
+++ b/group/557.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/558.html
+++ b/group/558.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/559.html
+++ b/group/559.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/56.html
+++ b/group/56.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/560.html
+++ b/group/560.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/561.html
+++ b/group/561.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/562.html
+++ b/group/562.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/563.html
+++ b/group/563.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/564.html
+++ b/group/564.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/565.html
+++ b/group/565.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/566.html
+++ b/group/566.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/567.html
+++ b/group/567.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/568.html
+++ b/group/568.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/569.html
+++ b/group/569.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/57.html
+++ b/group/57.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/570.html
+++ b/group/570.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/571.html
+++ b/group/571.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/572.html
+++ b/group/572.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/573.html
+++ b/group/573.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/574.html
+++ b/group/574.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/575.html
+++ b/group/575.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/576.html
+++ b/group/576.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/577.html
+++ b/group/577.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/578.html
+++ b/group/578.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/579.html
+++ b/group/579.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/58.html
+++ b/group/58.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/580.html
+++ b/group/580.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/581.html
+++ b/group/581.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/582.html
+++ b/group/582.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/583.html
+++ b/group/583.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/584.html
+++ b/group/584.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/585.html
+++ b/group/585.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/586.html
+++ b/group/586.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/587.html
+++ b/group/587.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/588.html
+++ b/group/588.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/589.html
+++ b/group/589.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/59.html
+++ b/group/59.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/590.html
+++ b/group/590.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/591.html
+++ b/group/591.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/592.html
+++ b/group/592.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/593.html
+++ b/group/593.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/594.html
+++ b/group/594.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/595.html
+++ b/group/595.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/596.html
+++ b/group/596.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/597.html
+++ b/group/597.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/598.html
+++ b/group/598.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/599.html
+++ b/group/599.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/6.html
+++ b/group/6.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/60.html
+++ b/group/60.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/600.html
+++ b/group/600.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/601.html
+++ b/group/601.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/602.html
+++ b/group/602.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/603.html
+++ b/group/603.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/604.html
+++ b/group/604.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/605.html
+++ b/group/605.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/606.html
+++ b/group/606.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/607.html
+++ b/group/607.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/608.html
+++ b/group/608.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/609.html
+++ b/group/609.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/61.html
+++ b/group/61.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/610.html
+++ b/group/610.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/611.html
+++ b/group/611.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/612.html
+++ b/group/612.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/613.html
+++ b/group/613.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/614.html
+++ b/group/614.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/615.html
+++ b/group/615.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/616.html
+++ b/group/616.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/617.html
+++ b/group/617.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/618.html
+++ b/group/618.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/619.html
+++ b/group/619.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/62.html
+++ b/group/62.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/620.html
+++ b/group/620.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/621.html
+++ b/group/621.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/622.html
+++ b/group/622.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/623.html
+++ b/group/623.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/624.html
+++ b/group/624.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/625.html
+++ b/group/625.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/626.html
+++ b/group/626.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/627.html
+++ b/group/627.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/628.html
+++ b/group/628.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/629.html
+++ b/group/629.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/63.html
+++ b/group/63.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/630.html
+++ b/group/630.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/631.html
+++ b/group/631.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/632.html
+++ b/group/632.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/633.html
+++ b/group/633.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/634.html
+++ b/group/634.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/635.html
+++ b/group/635.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/636.html
+++ b/group/636.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/637.html
+++ b/group/637.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/638.html
+++ b/group/638.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/639.html
+++ b/group/639.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/64.html
+++ b/group/64.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/640.html
+++ b/group/640.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/641.html
+++ b/group/641.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/642.html
+++ b/group/642.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/643.html
+++ b/group/643.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/644.html
+++ b/group/644.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/645.html
+++ b/group/645.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/646.html
+++ b/group/646.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/647.html
+++ b/group/647.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/648.html
+++ b/group/648.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/649.html
+++ b/group/649.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/65.html
+++ b/group/65.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/66.html
+++ b/group/66.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/67.html
+++ b/group/67.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/68.html
+++ b/group/68.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/69.html
+++ b/group/69.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/7.html
+++ b/group/7.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/70.html
+++ b/group/70.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/71.html
+++ b/group/71.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/72.html
+++ b/group/72.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/73.html
+++ b/group/73.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/74.html
+++ b/group/74.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/75.html
+++ b/group/75.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/76.html
+++ b/group/76.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/77.html
+++ b/group/77.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/78.html
+++ b/group/78.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/79.html
+++ b/group/79.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/8.html
+++ b/group/8.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/80.html
+++ b/group/80.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/81.html
+++ b/group/81.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/82.html
+++ b/group/82.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/83.html
+++ b/group/83.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/84.html
+++ b/group/84.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/85.html
+++ b/group/85.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/86.html
+++ b/group/86.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/87.html
+++ b/group/87.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/88.html
+++ b/group/88.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/89.html
+++ b/group/89.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/9.html
+++ b/group/9.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/90.html
+++ b/group/90.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/91.html
+++ b/group/91.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/92.html
+++ b/group/92.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/93.html
+++ b/group/93.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/94.html
+++ b/group/94.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/95.html
+++ b/group/95.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/96.html
+++ b/group/96.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/97.html
+++ b/group/97.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/98.html
+++ b/group/98.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/group/99.html
+++ b/group/99.html
@@ -16,12 +16,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 

--- a/movements/churn_butter/index.html
+++ b/movements/churn_butter/index.html
@@ -12,12 +12,6 @@ h3    { font-size: 100%; }
 -->
 </style>
 
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 </head>
     
 <body bgcolor="#ffffff">

--- a/testimonials.html
+++ b/testimonials.html
@@ -17,12 +17,6 @@ pre   { background: #F0F0F0; }
 -->
 
 </style>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 
 </head>
 <body>

--- a/useful_vs_functional.html
+++ b/useful_vs_functional.html
@@ -13,12 +13,6 @@ h3    { font-size: 100%; }
 .tiny { font-family: arial; font-size: 10px; font-style: normal; font-weight: normal; }
 -->
 </style>
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-97636-2";
-urchinTracker();
-</script>
 
 </head>
     


### PR DESCRIPTION
## Summary
- delete old `urchin.js` tracking scripts from all HTML pages

## Testing
- `grep -R "urchin.js" -n`

------
https://chatgpt.com/codex/tasks/task_e_6865873a7d94832b94a6ffa6cac8c26d